### PR TITLE
Added regkey checks

### DIFF
--- a/controls/windows.rb
+++ b/controls/windows.rb
@@ -30,4 +30,16 @@ control 'Meltdown and Spectre Vulnerability Check (Windows)' do
       end
     end
   end
+
+  describe registry_key('FeatureSettingOverride','HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management') do
+    its('FeatureSettingsOverride') { should eq 0 }
+  end
+
+  describe registry_key('FeatureSettingOverridemask','HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management') do
+    its('FeatureSettingsOverrideMask') { should eq 3 }
+  end
+
+  describe registry_key('MinVmVersionForCpuBasedMitigations'),'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization') do
+    its('MinVmVersionForCpuBasedMitigations') { should eq '1.0'}
+  end
 end


### PR DESCRIPTION
Added in the registry keys that need to be set to enable the mitigations in the OS patches. Doesn't do any checks on whether the mitigations are active or if the server has been rebooted since the keys were flipped.